### PR TITLE
Fix hash computation in IDToken.verify_hash/4

### DIFF
--- a/lib/oidc/id_token.ex
+++ b/lib/oidc/id_token.ex
@@ -393,7 +393,7 @@ defmodule OIDC.IDToken do
 
   @doc """
   Verifies an hash-claim of an ID token
-  
+
   The token hash name is one of:
   - `"c_hash"`
   - `"at_hash"`
@@ -412,7 +412,7 @@ defmodule OIDC.IDToken do
 
     computed_token_hash =
       hashed_token
-      |> String.slice(0, div(byte_size(hashed_token), 2) - 1)
+      |> binary_part(0, div(byte_size(hashed_token), 2))
       |> Base.url_encode64(padding: false)
 
     if computed_token_hash == claims[token_hash_name] do


### PR DESCRIPTION
I'm using [Boruta library](https://gitlab.com/patatoid/boruta_auth/-/blob/openid-connect/lib/boruta/oauth/schemas/id_token.ex#L98) to create ID Token.

When I tried to verify it's `c_hash` using `OIDC.IDToken.verify_hash/4`, I got error.
Switching to `binary_part(0, div(byte_size(hashed_token), 2))` helped.